### PR TITLE
Add more options to number-secondary widget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 .yardoc
 .project
 .idea
+.ruby-version
+.ruby-gemset
 Gemfile.lock
 InstalledFiles
 _yardoc

--- a/lib/gecko/widget/number_secondary_stat.rb
+++ b/lib/gecko/widget/number_secondary_stat.rb
@@ -1,17 +1,22 @@
 module Gecko
   class Widget
     class NumberSecondaryStat < Widget
-      attr_accessor :primary_text, :primary_value, :secondary_text, :secondary_value
+      attr_accessor :primary_text, :primary_value, :primary_prefix, :secondary_text, :secondary_value, :secondary_prefix, :absolute, :type
 
       def data_payload
         {:item =>
           [{
            :text => self.primary_text,
-           :value => self.primary_value
+           :value => self.primary_value,
+           :prefix => self.primary_prefix
          }, {
            :text => self.secondary_text,
-           :value => self.secondary_value
-         }]}
+           :value => self.secondary_value,
+           :prefix => self.secondary_prefix
+         }],
+         :absolute => self.absolute,
+         :type => self.type
+        }
       end
     end
   end

--- a/spec/gecko/number_and_secondary_stat_spec.rb
+++ b/spec/gecko/number_and_secondary_stat_spec.rb
@@ -11,18 +11,21 @@ describe Gecko::Widget::NumberSecondaryStat do
     it 'should be empty by default' do
       expect(@widget.payload).to be_a_valid_payload(
         TEST_API_KEY,
-        {:item => [{:value => nil, :text => nil}, {:value => nil, :text => nil}]}
+        {:item => [{:value => nil, :text => nil, :prefix => nil}, {:value => nil, :text => nil, :prefix => nil}], :absolute => nil, :type => nil}
       )
     end
 
     it 'should be correct hash when values assigned' do
       @widget.primary_text = 'text A'
       @widget.primary_value = 1
+      @widget.primary_prefix = "$"
       @widget.secondary_text = 'text B'
       @widget.secondary_value = 2
+      @widget.absolute = "true"
+      @widget.type = "reverse"
       expect(@widget.payload).to be_a_valid_payload(
         TEST_API_KEY,
-        {:item => [{:value => 1, :text => 'text A'}, {:value => 2, :text => 'text B'}]}
+        {:item => [{:value => 1, :text => 'text A', :prefix => "$"}, {:value => 2, :text => 'text B', :prefix => nil}], :absolute => "true", :type => "reverse"}
       )
     end
   end


### PR DESCRIPTION
I've added the new options for the Number and Secondary chart. I've tested it on my own Geckoboard dashboard and it works.

You should be able to merge the pull request and just push out a new version of the gem.

Thanks for putting this together!
