### PR TITLE
Relaxed dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: ruby
+sudo: false
 rvm:
   - "1.8.7"
   - "1.9.2"
   - "1.9.3"
+  - "2.3.3"
+  - "2.4.1"
 script: bundle exec rspec spec
+before_install:
+  - gem install bundler -v 1.15.4

--- a/gecko.gemspec
+++ b/gecko.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "pry"
   gem.add_development_dependency "awesome_print"
   gem.add_development_dependency "yajl-ruby", "~> 1.1"
-  gem.add_development_dependency "eventmachine", "~> 1.0.0"
-  gem.add_development_dependency "em-http-request", "~> 1.0.0"
+  gem.add_development_dependency "eventmachine", "~> 1.0"
+  gem.add_development_dependency "em-http-request", "~> 1.0"
 
-  gem.add_development_dependency 'rspec'
+  gem.add_development_dependency 'rspec', '~> 3.6'
 end

--- a/gecko.gemspec
+++ b/gecko.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "pry"
   gem.add_development_dependency "awesome_print"
   gem.add_development_dependency "yajl-ruby", "~> 1.1"
+  gem.add_development_dependency 'addressable', '~> 2.3.4'
   gem.add_development_dependency "eventmachine", "~> 1.0"
   gem.add_development_dependency "em-http-request", "~> 1.0"
 

--- a/gecko.gemspec
+++ b/gecko.gemspec
@@ -15,13 +15,13 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Gecko::VERSION
 
-  gem.add_dependency "faraday", "~> 0.8.4"
-  gem.add_dependency "faraday_middleware-multi_json", "~> 0.0.4"
+  gem.add_dependency "faraday", "~> 0.8"
+  gem.add_dependency "faraday_middleware-multi_json", "~> 0.0"
   gem.add_dependency "multi_json"
 
   gem.add_development_dependency "pry"
   gem.add_development_dependency "awesome_print"
-  gem.add_development_dependency "yajl-ruby", "~> 1.1.0"
+  gem.add_development_dependency "yajl-ruby", "~> 1.1"
   gem.add_development_dependency "eventmachine", "~> 1.0.0"
   gem.add_development_dependency "em-http-request", "~> 1.0.0"
 

--- a/spec/gecko/text_spec.rb
+++ b/spec/gecko/text_spec.rb
@@ -6,7 +6,7 @@ describe Gecko::Widget::Text do
   describe described_class::Item do
     describe '#initialize' do
       it 'should raise error if undefined type given' do
-        expect{ described_class::Item.new('text', :undefined_type) }.to raise_error(ArgumentError)
+        expect{ described_class.new('text', :undefined_type) }.to raise_error(ArgumentError)
       end
     end
   end

--- a/spec/gecko_spec.rb
+++ b/spec/gecko_spec.rb
@@ -18,13 +18,13 @@ describe Gecko do
 
     it '#http_builder by default should not respond to call' do
       described_class.config.http_builder # nil out any previous values
-      expect(described_class.config.connection_builder.respond_to?(:call)).to be_false
+      expect(described_class.config.connection_builder.respond_to?(:call)).to be false
     end
 
     it '#http_builder should allow setting via block' do
       proc = Proc.new { 1 }
       described_class.config.http_builder(&proc)
-      expect(described_class.config.connection_builder.respond_to?(:call)).to be_true
+      expect(described_class.config.connection_builder.respond_to?(:call)).to be true
       expect(described_class.config.connection_builder).to be proc
     end
   end

--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -5,7 +5,7 @@ describe Gecko::Http do
     stub = Faraday::Adapter::Test::Stubs.new do |stub|
       stub.post(url, MultiJson.encode(request_body), &response)
     end
-    described_class.new do |builder|
+    Gecko::Http.new do |builder|
       builder.adapter :test, stub
     end
   end
@@ -57,15 +57,15 @@ describe Gecko::Http do
         end
 
         it '#http_200? should be true' do
-          expect(@response.http_200?).to be_true
+          expect(@response.http_200?).to be true
         end
 
         it '#error? should be false' do
-          expect(@response.error?).to be_false
+          expect(@response.error?).to be false
         end
 
         it '#success? should be true' do
-          expect(@response.success?).to be_true
+          expect(@response.success?).to be true
         end
 
         it '#fetch should work with nested keys' do
@@ -77,7 +77,7 @@ describe Gecko::Http do
         end
 
         it '#error should return an Error instance' do
-          expect(@response.error).to be_a(described_class::Result::Error)
+          expect(@response.error).to be_a(described_class::Error)
         end
 
         it '#error should be empty' do
@@ -87,7 +87,7 @@ describe Gecko::Http do
         end
 
         it '#on_complete should call block with correct params' do
-          expect{ |p| @response.on_complete(&p) }.to yield_with_args(true, described_class::Result)
+          expect{ |p| @response.on_complete(&p) }.to yield_with_args(true, described_class)
         end
       end
 
@@ -102,15 +102,15 @@ describe Gecko::Http do
         end
 
         it '#http_200? should be true' do
-          expect(@response.http_200?).to be_false
+          expect(@response.http_200?).to be false
         end
 
         it '#error? should be false' do
-          expect(@response.error?).to be_true
+          expect(@response.error?).to be true
         end
 
         it '#success? should be true' do
-          expect(@response.success?).to be_false
+          expect(@response.success?).to be false
         end
 
         it '#fetch should work with nested keys' do
@@ -122,7 +122,7 @@ describe Gecko::Http do
         end
 
         it '#error should return an Error instance' do
-          expect(@response.error).to be_a(described_class::Result::Error)
+          expect(@response.error).to be_a(described_class::Error)
         end
 
         it '#error should be populated' do
@@ -132,7 +132,7 @@ describe Gecko::Http do
         end
 
         it '#on_complete should call block with correct params' do
-          expect { |p| @response.on_complete(&p) }.to yield_with_args(false, described_class::Result)
+          expect { |p| @response.on_complete(&p) }.to yield_with_args(false, described_class)
         end
       end
     end

--- a/spec/widget_spec.rb
+++ b/spec/widget_spec.rb
@@ -31,7 +31,7 @@ describe Gecko::Widget do
       it 'should return 1 request objects' do
         update_result = @widget.update
         expect(update_result).to be_a(Array)
-        expect(update_result).to have(1).items
+        expect(update_result.length).to eql(1)
         update_result.each do |result|
           expect(result).to be_a(Gecko::Http::Result)
         end
@@ -39,8 +39,8 @@ describe Gecko::Widget do
 
       it 'should evoke callback passed to #update' do
         callback = MockBlock.new
-        callback.should_receive(:call).once.with do |success, result, key|
-          expect(success).to be_true
+        expect(callback).to receive(:call).once do |success, result, key|
+          expect(success).to be true
           expect(result).to be_a(Gecko::Http::Result)
           expect(key).to eq('widget_key1')
         end
@@ -49,8 +49,8 @@ describe Gecko::Widget do
 
       it 'should evoke callback passed to #on_update' do
         callback = MockBlock.new
-        callback.should_receive(:call).once.with do |success, result, key|
-          expect(success).to be_true
+        expect(callback).to receive(:call).once do |success, result, key|
+          expect(success).to be true
           expect(result).to be_a(Gecko::Http::Result)
           expect(key).to eq('widget_key1')
         end
@@ -62,7 +62,7 @@ describe Gecko::Widget do
         let(:http_response) { @widget.update.first }
 
         it 'should have no errors' do
-          expect(http_response.error?).to be_false
+          expect(http_response.error?).to be false
         end
       end
 
@@ -80,7 +80,7 @@ describe Gecko::Widget do
       it 'should return 2 request objects' do
         update_result = @widget.update
         expect(update_result).to be_a(Array)
-        expect(update_result).to have(2).items
+        expect(update_result.length).to eql(2)
         update_result.each do |result|
           expect(result).to be_a(Gecko::Http::Result)
         end
@@ -88,8 +88,8 @@ describe Gecko::Widget do
 
       it 'should evoke callback passed to #update' do
         callback = MockBlock.new
-        callback.should_receive(:call).twice.with do |success, result, key|
-          expect(success).to be_true
+        expect(callback).to receive(:call).twice do |success, result, key|
+          expect(success).to be true
           expect(result).to be_a(Gecko::Http::Result)
           expect(key).to match(/widget_key[1|2]/)
         end
@@ -98,8 +98,8 @@ describe Gecko::Widget do
 
       it 'should evoke callback passed to #on_update' do
         callback = MockBlock.new
-        callback.should_receive(:call).twice.with do |success, result, key|
-          expect(success).to be_true
+        expect(callback).to receive(:call).twice do |success, result, key|
+          expect(success).to be true
           expect(result).to be_a(Gecko::Http::Result)
           expect(key).to match(/widget_key[1|2]/)
         end
@@ -112,7 +112,7 @@ describe Gecko::Widget do
 
         it 'should have no errors' do
           http_responses.each do |http_response|
-            expect(http_response.error?).to be_false
+            expect(http_response.error?).to be false
           end
         end
       end
@@ -130,7 +130,7 @@ describe Gecko::Widget do
       it 'should return 2 request objects' do
         update_result = @widget.update
         expect(update_result).to be_a(Array)
-        expect(update_result).to have(2).items
+        expect(update_result.length).to eql(2)
         update_result.each do |result|
           expect(result).to be_a(Gecko::Http::Result)
         end
@@ -138,8 +138,8 @@ describe Gecko::Widget do
 
       it 'should evoke callback passed to #update' do
         callback = MockBlock.new
-        callback.should_receive(:call).twice.with do |success, result, key|
-          expect(success).to be_false
+        expect(callback).to receive(:call).twice do |success, result, key|
+          expect(success).to be false
           expect(result).to be_a(Gecko::Http::Result)
           expect(key).to match(/widget_key[1|2]/)
         end
@@ -148,8 +148,8 @@ describe Gecko::Widget do
 
       it 'should evoke callback passed to #on_update' do
         callback = MockBlock.new
-        callback.should_receive(:call).twice.with do |success, result, key|
-          expect(success).to be_false
+        expect(callback).to receive(:call).twice do |success, result, key|
+          expect(success).to be false
           expect(result).to be_a(Gecko::Http::Result)
           expect(key).to match(/widget_key[1|2]/)
         end
@@ -162,7 +162,7 @@ describe Gecko::Widget do
 
         it 'should have errors' do
           http_responses.each do |http_response|
-            expect(http_response.error?).to be_true
+            expect(http_response.error?).to be true
             expect(http_response.error.to_s).to eq('Push operation failed due to an unknown reason. Please try again!')
           end
         end


### PR DESCRIPTION
* faraday dep is now minor ver pessimistic
* faraday_middleware-multi_json is now minor ver pessimistic
* yajl-ruby is now minor ver pessimistic
* eventmachine (devdep) is now minor ver pessimistic
* em-http-request (devdep) is now minor ver pessimistic
* rspec (devdep) is now `~> 3.6`

This *should* help with usage while using other gems that require
newer versions of these, at least to some degree.

Additionally, this includes minor updates to the tests to make them jibe with a newer rspec.